### PR TITLE
Fix asset load error in custom theme module

### DIFF
--- a/addons/UI_UX_DVC/__manifest__.py
+++ b/addons/UI_UX_DVC/__manifest__.py
@@ -25,9 +25,7 @@
         ],
     },
     'data': [
-        'views/backend_assets.xml',
         'views/backend_menu_customization.xml',
-        'views/frontend_assets.xml',
         'views/website_templates.xml',
     ],
     'installable': True,

--- a/addons/UI_UX_DVC/views/backend_assets.xml
+++ b/addons/UI_UX_DVC/views/backend_assets.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <template id="assets_backend" inherit_id="web.assets_backend">
-        <xpath expr="." position="inside">
-            <link rel="stylesheet" type="text/scss" href="/UI_UX_DVC/static/src/scss/backend_theme.scss"/>
-            <script type="text/javascript" src="/UI_UX_DVC/static/src/js/backend_customization.js"/>
-        </xpath>
-    </template>
-</odoo>

--- a/addons/UI_UX_DVC/views/frontend_assets.xml
+++ b/addons/UI_UX_DVC/views/frontend_assets.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-    <template id="assets_frontend" name="DUX MACHINA Frontend Assets" inherit_id="web.assets_frontend">
-        <xpath expr="." position="inside">
-            <link rel="stylesheet" type="scss" href="/UI_UX_DVC/static/src/scss/frontend_theme.scss"/>
-            <script type="module" src="/UI_UX_DVC/static/src/js/frontend_customization.js"/>
-        </xpath>
-    </template>
-</odoo>


### PR DESCRIPTION
## Summary
- remove unused XML asset files
- rely on manifest asset declarations

## Testing
- `python -m py_compile addons/UI_UX_DVC/__manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_687c63dd5398832ca2640149f062d25a