### PR TITLE
Fix dark theme initialization and styles

### DIFF
--- a/addons/UI_UX_DVC/static/src/js/navbar_extension.js
+++ b/addons/UI_UX_DVC/static/src/js/navbar_extension.js
@@ -1,12 +1,14 @@
 /** @odoo-module **/
 import { Component } from '@odoo/owl';
 import { registry } from '@web/core/registry';
+import { useService } from '@web/core/utils/hooks';
 
-class ThemeToggleSystray extends Component {
+export class ThemeToggleSystray extends Component {
     static template = 'ui_ux_dvc.ThemeToggleSystray';
+    static props = {};
 
     setup() {
-        this.themeService = this.env.services.dux_theme;
+        this.themeService = useService('dux_theme');
     }
 
     toggle() {
@@ -18,7 +20,8 @@ class ThemeToggleSystray extends Component {
     }
 }
 
-registry.category('systray').add('ui_ux_dvc.theme_toggle', {
+export const systrayItem = {
     Component: ThemeToggleSystray,
-    sequence: 1,
-});
+};
+
+registry.category('systray').add('ui_ux_dvc.theme_toggle', systrayItem, { sequence: 1 });

--- a/addons/UI_UX_DVC/static/src/js/theme_init.js
+++ b/addons/UI_UX_DVC/static/src/js/theme_init.js
@@ -1,6 +1,14 @@
 /** @odoo-module **/
 import { registry } from '@web/core/registry';
 
-registry.category('services').whenReady('dux_theme').then((service) => {
-    service.apply(service.theme);
-});
+async function initTheme() {
+    if (document.readyState === 'loading') {
+        await new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+    }
+    const themeService = await registry.category('services').get('dux_theme');
+    if (themeService) {
+        themeService.apply(themeService.theme);
+    }
+}
+
+initTheme();

--- a/addons/UI_UX_DVC/static/src/js/theme_service.js
+++ b/addons/UI_UX_DVC/static/src/js/theme_service.js
@@ -9,7 +9,8 @@ export const themeService = {
         const state = { theme: initial };
 
         function apply(theme) {
-            document.documentElement.classList.toggle('dux-theme-dark', theme === 'dark');
+            const client = document.querySelector('.o_web_client');
+            (client || document.documentElement).classList.toggle('dux-theme-dark', theme === 'dark');
             state.theme = theme;
             localStorage.setItem(STORAGE_KEY, theme);
         }

--- a/addons/UI_UX_DVC/static/src/scss/components/forms.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/forms.scss
@@ -1,8 +1,11 @@
 @use "../mixins" as m;
 
 .o_web_client.dux-theme-dark {
-    .o_form_view .o_form_sheet_bg {
-        @include m.glass-morphism(10px);
-        border-radius: 12px;
+    .o_form_sheet_bg {
+        .o_form_sheet {
+            @include m.glass-morphism();
+            border-radius: 12px;
+            @include m.transition-base;
+        }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/components/lists.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/lists.scss
@@ -1,7 +1,17 @@
 @use "../mixins" as m;
 
 .o_web_client.dux-theme-dark {
-    .o_list_view .table {
-        @include m.glass-morphism(10px);
+    .o_list_view {
+        .table {
+            @include m.glass-morphism();
+            border-radius: 12px;
+            @include m.transition-base;
+            thead th {
+                background-color: rgba(255, 255, 255, 0.05);
+            }
+            tbody tr:hover {
+                background-color: rgba(255, 255, 255, 0.07);
+            }
+        }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/components/modals.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/modals.scss
@@ -1,8 +1,11 @@
 @use "../mixins" as m;
 
 .o_web_client.dux-theme-dark {
-    .modal-content {
-        @include m.glass-morphism(10px);
-        border-radius: 12px;
+    .modal-dialog {
+        .modal-content {
+            @include m.glass-morphism();
+            border-radius: 12px;
+            @include m.transition-base;
+        }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
@@ -2,9 +2,17 @@
 
 .o_web_client.dux-theme-dark {
     header.o_navbar {
-        @include m.glass-morphism(10px);
+        @include m.glass-morphism();
+        @include m.transition-base;
         .o_menu_brand {
             color: var(--dux-secondary-color);
+        }
+        .o_ux_theme_toggle {
+            border-radius: 8px;
+            @include m.transition-base;
+            &:hover {
+                background: rgba(255, 255, 255, 0.1);
+            }
         }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/mixins.scss
+++ b/addons/UI_UX_DVC/static/src/scss/mixins.scss
@@ -1,10 +1,11 @@
 // Mixins for DUX MACHINA theme
 
-@mixin glass-morphism($blur: 10px, $bg: rgba(255, 255, 255, 0.05)) {
+@mixin glass-morphism($blur: 15px, $bg: rgba(255, 255, 255, 0.05), $shadow: 0 4px 30px rgba(0, 0, 0, 0.1)) {
     background: $bg;
     backdrop-filter: blur($blur);
     -webkit-backdrop-filter: blur($blur);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: $shadow;
 }
 
 @mixin transition-base {

--- a/addons/UI_UX_DVC/static/src/scss/theme_base.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_base.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
 @use "colors";
 @use "mixins";
 
@@ -6,7 +8,12 @@
     font-family: 'Inter', sans-serif;
 }
 
-@import "components/navbar";
-@import "components/forms";
-@import "components/lists";
-@import "components/modals";
+.o_web_client {
+    @include mixins.transition-base;
+    font-family: 'Inter', sans-serif;
+}
+
+@use "components/navbar";
+@use "components/forms";
+@use "components/lists";
+@use "components/modals";

--- a/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
@@ -1,6 +1,36 @@
 @use "mixins";
+@use "colors";
 
 .o_web_client.dux-theme-dark {
-    background: #0A0E27;
+    background: var(--dux-primary-color);
     color: #ffffff;
+    font-family: 'Inter', sans-serif;
+    input,
+    textarea,
+    select {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        color: #fff;
+        @include mixins.transition-base;
+    }
+    .btn {
+        background: rgba(255, 255, 255, 0.08);
+        border-color: rgba(255, 255, 255, 0.15);
+        color: #fff;
+        @include mixins.transition-base;
+        &:hover {
+            background: rgba(255, 255, 255, 0.15);
+        }
+    }
+    .card {
+        @include mixins.glass-morphism();
+        border-radius: 12px;
+    }
+    table.table tr:hover {
+        background: rgba(255, 255, 255, 0.05);
+    }
+    .dropdown-menu {
+        @include mixins.glass-morphism();
+        border-radius: 12px;
+    }
 }


### PR DESCRIPTION
## Summary
- ensure theme class is applied to `.o_web_client`
- wait for DOM ready before applying theme
- register theme toggle systray item correctly
- include Google font and use SCSS modules
- add dark theme styles and glass morphism

## Testing
- `python -m compileall addons/UI_UX_DVC`

------
https://chatgpt.com/codex/tasks/task_e_687d0f2b4b6c832ca7510f20022b02cb