### PR TITLE
Fix theme service initialization

### DIFF
--- a/addons/UI_UX_DVC/static/src/js/theme_init.js
+++ b/addons/UI_UX_DVC/static/src/js/theme_init.js
@@ -1,14 +1,11 @@
 /** @odoo-module **/
-import { registry } from '@web/core/registry';
+import { whenReady } from '@odoo/owl';
 
-async function initTheme() {
-    if (document.readyState === 'loading') {
-        await new Promise(resolve => document.addEventListener('DOMContentLoaded', resolve, { once: true }));
-    }
-    const themeService = await registry.category('services').get('dux_theme');
-    if (themeService) {
-        themeService.apply(themeService.theme);
-    }
-}
-
-initTheme();
+whenReady(() => {
+    setTimeout(() => {
+        const themeService = odoo.env.services?.dux_theme;
+        if (themeService && themeService.apply) {
+            themeService.apply(themeService.theme);
+        }
+    }, 100);
+});

--- a/addons/UI_UX_DVC/static/src/js/theme_service.js
+++ b/addons/UI_UX_DVC/static/src/js/theme_service.js
@@ -4,7 +4,8 @@ import { registry } from '@web/core/registry';
 export const themeService = {
     start(env) {
         const STORAGE_KEY = 'dux-theme';
-        const initial = localStorage.getItem(STORAGE_KEY) || (env.config.mode === 'dark' ? 'dark' : 'light');
+        const defaultTheme = env.config && env.config.mode === 'dark' ? 'dark' : 'light';
+        const initial = localStorage.getItem(STORAGE_KEY) || defaultTheme;
 
         const state = { theme: initial };
 


### PR DESCRIPTION
## Summary
- protect against missing `env.config` in theme service
- initialize theme after Odoo environment is ready

## Testing
- `node -c addons/UI_UX_DVC/static/src/js/theme_service.js && node -c addons/UI_UX_DVC/static/src/js/theme_init.js`

------
https://chatgpt.com/codex/tasks/task_e_687d17097d30832c9c7313141fb6a282