### PR TITLE
Fix SCSS mixin imports

### DIFF
--- a/addons/UI_UX_DVC/static/src/scss/components/forms.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/forms.scss
@@ -1,11 +1,11 @@
-@use "../mixins" as m;
+@import "../mixins";
 
 .o_web_client.dux-theme-dark {
     .o_form_sheet_bg {
         .o_form_sheet {
-            @include m.glass-morphism();
+            @include glass-morphism();
             border-radius: 12px;
-            @include m.transition-base;
+            @include transition-base;
         }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/components/lists.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/lists.scss
@@ -1,11 +1,11 @@
-@use "../mixins" as m;
+@import "../mixins";
 
 .o_web_client.dux-theme-dark {
     .o_list_view {
         .table {
-            @include m.glass-morphism();
+            @include glass-morphism();
             border-radius: 12px;
-            @include m.transition-base;
+            @include transition-base;
             thead th {
                 background-color: rgba(255, 255, 255, 0.05);
             }

--- a/addons/UI_UX_DVC/static/src/scss/components/modals.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/modals.scss
@@ -1,11 +1,11 @@
-@use "../mixins" as m;
+@import "../mixins";
 
 .o_web_client.dux-theme-dark {
     .modal-dialog {
         .modal-content {
-            @include m.glass-morphism();
+            @include glass-morphism();
             border-radius: 12px;
-            @include m.transition-base;
+            @include transition-base;
         }
     }
 }

--- a/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
@@ -1,15 +1,15 @@
-@use "../mixins" as m;
+@import "../mixins";
 
 .o_web_client.dux-theme-dark {
     header.o_navbar {
-        @include m.glass-morphism();
-        @include m.transition-base;
+        @include glass-morphism();
+        @include transition-base;
         .o_menu_brand {
             color: var(--dux-secondary-color);
         }
         .o_ux_theme_toggle {
             border-radius: 8px;
-            @include m.transition-base;
+            @include transition-base;
             &:hover {
                 background: rgba(255, 255, 255, 0.1);
             }

--- a/addons/UI_UX_DVC/static/src/scss/theme_base.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_base.scss
@@ -1,11 +1,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
-@use "colors";
-@use "mixins";
-@use "components/navbar";
-@use "components/forms";
-@use "components/lists";
-@use "components/modals";
+// Import mixins first
+@import "mixins";
+@import "colors";
+
+// Then import components
+@import "components/navbar";
+@import "components/forms";
+@import "components/lists";
+@import "components/modals";
 
 .o_web_client.dux-theme-dark {
     color-scheme: dark;
@@ -13,6 +16,6 @@
 }
 
 .o_web_client {
-    @include mixins.transition-base;
+    @include transition-base;
     font-family: 'Inter', sans-serif;
 }

--- a/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
@@ -1,5 +1,5 @@
-@use "mixins";
-@use "colors";
+@import "mixins";
+@import "colors";
 
 .o_web_client.dux-theme-dark {
     background: var(--dux-primary-color);
@@ -11,26 +11,26 @@
         background: rgba(255, 255, 255, 0.05);
         border: 1px solid rgba(255, 255, 255, 0.2);
         color: #fff;
-        @include mixins.transition-base;
+        @include transition-base;
     }
     .btn {
         background: rgba(255, 255, 255, 0.08);
         border-color: rgba(255, 255, 255, 0.15);
         color: #fff;
-        @include mixins.transition-base;
+        @include transition-base;
         &:hover {
             background: rgba(255, 255, 255, 0.15);
         }
     }
     .card {
-        @include mixins.glass-morphism();
+        @include glass-morphism();
         border-radius: 12px;
     }
     table.table tr:hover {
         background: rgba(255, 255, 255, 0.05);
     }
     .dropdown-menu {
-        @include mixins.glass-morphism();
+        @include glass-morphism();
         border-radius: 12px;
     }
 }


### PR DESCRIPTION
## Summary
- fix theme_base.scss to use imports
- update components and dark theme to import mixins directly

## Testing
- `flake8 addons/UI_UX_DVC/static/src/scss`
- `python3 - <<'PY'
import sass
css = sass.compile(filename='addons/UI_UX_DVC/static/src/scss/theme_base.scss')
print(css[:200])
PY`
- `python3 - <<'PY'
import sass
css = sass.compile(filename='addons/UI_UX_DVC/static/src/scss/theme_dark.scss')
print(css[:200])
PY`


------
https://chatgpt.com/codex/tasks/task_e_687d261016d4832ca4f483656a63d590