### PR TITLE
Fix SCSS asset loading

### DIFF
--- a/addons/UI_UX_DVC/__manifest__.py
+++ b/addons/UI_UX_DVC/__manifest__.py
@@ -22,7 +22,16 @@
             ),
         ],
         'web.assets_backend': [
+            # Load mixins first
+            'UI_UX_DVC/static/src/scss/mixins.scss',
+            # Then components
+            'UI_UX_DVC/static/src/scss/components/navbar.scss',
+            'UI_UX_DVC/static/src/scss/components/forms.scss',
+            'UI_UX_DVC/static/src/scss/components/lists.scss',
+            'UI_UX_DVC/static/src/scss/components/modals.scss',
+            # Then main theme
             'UI_UX_DVC/static/src/scss/theme_base.scss',
+            # JS files
             'UI_UX_DVC/static/src/js/theme_service.js',
             'UI_UX_DVC/static/src/js/theme_init.js',
             'UI_UX_DVC/static/src/js/navbar_extension.js',

--- a/addons/UI_UX_DVC/static/src/scss/components/forms.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/forms.scss
@@ -1,5 +1,3 @@
-@import "../mixins";
-
 .o_web_client.dux-theme-dark {
     .o_form_sheet_bg {
         .o_form_sheet {

--- a/addons/UI_UX_DVC/static/src/scss/components/lists.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/lists.scss
@@ -1,5 +1,3 @@
-@import "../mixins";
-
 .o_web_client.dux-theme-dark {
     .o_list_view {
         .table {

--- a/addons/UI_UX_DVC/static/src/scss/components/modals.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/modals.scss
@@ -1,5 +1,3 @@
-@import "../mixins";
-
 .o_web_client.dux-theme-dark {
     .modal-dialog {
         .modal-content {

--- a/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
+++ b/addons/UI_UX_DVC/static/src/scss/components/navbar.scss
@@ -1,5 +1,3 @@
-@import "../mixins";
-
 .o_web_client.dux-theme-dark {
     header.o_navbar {
         @include glass-morphism();

--- a/addons/UI_UX_DVC/static/src/scss/theme_base.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_base.scss
@@ -1,21 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
-// Import mixins first
-@import "mixins";
-@import "colors";
-
-// Then import components
-@import "components/navbar";
-@import "components/forms";
-@import "components/lists";
-@import "components/modals";
-
 .o_web_client.dux-theme-dark {
     color-scheme: dark;
     font-family: 'Inter', sans-serif;
 }
 
 .o_web_client {
-    @include transition-base;
+    transition: all 0.3s ease;
     font-family: 'Inter', sans-serif;
 }

--- a/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
+++ b/addons/UI_UX_DVC/static/src/scss/theme_dark.scss
@@ -1,6 +1,3 @@
-@import "mixins";
-@import "colors";
-
 .o_web_client.dux-theme-dark {
     background: var(--dux-primary-color);
     color: #ffffff;


### PR DESCRIPTION
## Summary
- load theme SCSS assets directly from the manifest
- drop local `@import` usage in all theme SCSS files

## Testing
- `python -m py_compile addons/UI_UX_DVC/__manifest__.py`


------
https://chatgpt.com/codex/tasks/task_e_687d2b03da68832c8fea2b9d223b30c4