### PR TITLE
Update theme settings view with fallback

### DIFF
--- a/addons/UI_UX_DVC/views/res_config_settings.xml
+++ b/addons/UI_UX_DVC/views/res_config_settings.xml
@@ -5,13 +5,44 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//form" position="inside">
-                <group string="DUX MACHINA Theme" class="mt-3">
-                    <field name="theme_default_dark"/>
-                    <field name="theme_glass_intensity"/>
-                    <field name="theme_accent_color" widget="color"/>
-                    <field name="theme_enable_animations"/>
-                </group>
+            <xpath expr="//div[@id='companies']" position="after">
+                <t t-if="'theme_default_dark' in res_config_settings._fields">
+                    <h2>DUX MACHINA Theme</h2>
+                    <div class="row mt16 o_settings_container" id="dux_theme_settings">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="theme_default_dark"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="theme_default_dark"/>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="theme_glass_intensity"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="theme_glass_intensity"/>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="theme_accent_color" widget="color"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="theme_accent_color"/>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane">
+                                <field name="theme_enable_animations"/>
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="theme_enable_animations"/>
+                            </div>
+                        </div>
+                    </div>
+                </t>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- insert theme settings block after the companies section
- wrap the block in a field existence check so the view doesn't break if fields are missing

## Testing
- `python -m py_compile addons/UI_UX_DVC/models/res_config_settings.py`

------
https://chatgpt.com/codex/tasks/task_e_687e98bc079c832c847b31ef2268eccb